### PR TITLE
Simplify multi-port voyage planner timing

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -447,8 +447,8 @@
             <span class="badge">new</span>
           </div>
 
-          <div class="grid sm:grid-cols-3 gap-3">
-            <div class="sm:col-span-3">
+          <div class="grid sm:grid-cols-2 gap-3">
+            <div class="sm:col-span-2">
               <label class="block text-sm font-medium text-gray-700 mb-1">Vessel Name</label>
               <input x-model="mpVesselName" class="w-full field" placeholder="Defaults to selected vessel name if blank" />
             </div>
@@ -456,10 +456,6 @@
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">Start Date</label>
               <input x-model="mpStartDate" type="date" class="w-full field" />
-            </div>
-            <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Days Between Ports</label>
-              <input x-model.number="mpDaysBetween" type="number" min="1" class="w-full field" />
             </div>
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">Days in Port</label>
@@ -523,7 +519,7 @@
           <div x-show="mpResult" class="mt-4">
             <div class="text-sm text-slate-600 mb-2">
               <div><span class="font-medium">Legs:</span> <span x-text="mpResult?.voyage_summary?.total_legs"></span> ·
-                   <span class="font-medium">Days:</span> <span x-text="mpResult?.voyage_summary?.total_days"></span></div>
+                   <span class="font-medium">Port Days:</span> <span x-text="mpResult?.voyage_summary?.total_days_in_port"></span></div>
             </div>
 
             <div class="overflow-x-auto">
@@ -643,7 +639,6 @@
         // multi-port
         mpVesselName: '',
         mpStartDate: new Date().toISOString().split('T')[0],
-        mpDaysBetween: 14,
         mpDaysInPort: 2,
         mpPortInput: '',
         mpPorts: [],
@@ -1331,7 +1326,6 @@
             vessel_name: vessel.name,
             ports: this.mpPorts.slice(),
             start_date: this.mpStartDate,
-            days_between_ports: Number(this.mpDaysBetween) || 14,
             days_in_port: Number(this.mpDaysInPort) || 2,
           };
   

--- a/src/maritime_mvp/api/routes.py
+++ b/src/maritime_mvp/api/routes.py
@@ -83,7 +83,6 @@ class PortSequenceRequest(BaseModel):
     vessel_name: str
     ports: List[str] = Field(..., example=["CNSHA", "USOAK", "USSEA", "USLAX"])
     start_date: date = Field(..., example="2025-09-01")
-    days_between_ports: int = Field(14, example=14)
     days_in_port: int = Field(2, example=2)
 
 
@@ -599,7 +598,7 @@ async def calculate_multi_port_voyage(
             }
         )
 
-        current_date += timedelta(days=request.days_in_port + request.days_between_ports)
+        current_date += timedelta(days=request.days_in_port)
 
     total_mandatory = sum(_dec(leg["fees"]["mandatory"]) for leg in voyage_legs)
     total_optional_high = sum(_dec(leg["fees"]["optional_high"]) for leg in voyage_legs)
@@ -609,7 +608,7 @@ async def calculate_multi_port_voyage(
         "voyage_summary": {
             "total_ports": len(request.ports),
             "total_legs": len(voyage_legs),
-            "total_days": (current_date - request.start_date).days,
+            "total_days_in_port": (current_date - request.start_date).days,
             "start_date": request.start_date.isoformat(),
             "end_date": current_date.isoformat(),
         },


### PR DESCRIPTION
## Summary
- remove the separate days-between field from the multi-port planner UI and clarify the displayed port-day summary
- send only the shared days_in_port value in multi-port planner requests
- update the multi-port API request model and scheduling logic to advance legs solely by days_in_port

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7274ff8b0832180ba0a1a9c199fc6