### PR TITLE
Normalize port hierarchy with zones and terminals

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,6 +1,18 @@
 BEGIN;
+
+CREATE TABLE IF NOT EXISTS port_zones (
+  id SERIAL PRIMARY KEY,
+  code VARCHAR(12) UNIQUE NOT NULL,
+  name VARCHAR(120) NOT NULL,
+  region VARCHAR(48),
+  primary_state CHAR(2),
+  country CHAR(2) DEFAULT 'US',
+  description TEXT
+);
+
 CREATE TABLE IF NOT EXISTS ports (
   id SERIAL PRIMARY KEY,
+  zone_id INTEGER REFERENCES port_zones (id) ON UPDATE CASCADE ON DELETE SET NULL,
   code VARCHAR(12) UNIQUE NOT NULL,
   name VARCHAR(120) NOT NULL,
   state CHAR(2),
@@ -12,6 +24,44 @@ CREATE TABLE IF NOT EXISTS ports (
   mx_url VARCHAR(512),
   tariff_url VARCHAR(512)
 );
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'ports' AND column_name = 'zone_id'
+  ) THEN
+    ALTER TABLE ports ADD COLUMN zone_id INTEGER;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'ports_zone_id_fkey'
+  ) THEN
+    ALTER TABLE ports
+      ADD CONSTRAINT ports_zone_id_fkey FOREIGN KEY (zone_id)
+      REFERENCES port_zones (id)
+      ON UPDATE CASCADE ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS ports_zone_id_idx
+  ON ports (zone_id);
+
+CREATE TABLE IF NOT EXISTS terminals (
+  id SERIAL PRIMARY KEY,
+  port_id INTEGER NOT NULL REFERENCES ports (id) ON DELETE CASCADE,
+  code VARCHAR(24) UNIQUE NOT NULL,
+  name VARCHAR(200) NOT NULL,
+  operator_name VARCHAR(200),
+  is_public BOOLEAN DEFAULT FALSE,
+  notes TEXT
+);
+
+CREATE INDEX IF NOT EXISTS terminals_port_id_idx
+  ON terminals (port_id);
 
 CREATE TABLE IF NOT EXISTS port_documents (
   id SERIAL PRIMARY KEY,

--- a/db/seeds/port_zones.sql
+++ b/db/seeds/port_zones.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+INSERT INTO port_zones (code, name, region, primary_state, country, description) VALUES
+  ('SOCAL', 'Southern California', 'SoCal', 'CA', 'US', 'Ports and harbors along the greater Los Angeles and Long Beach complex.'),
+  ('NORCAL', 'San Francisco Bay Area', 'NorCal', 'CA', 'US', 'Bay Area port authorities serving the San Francisco and Oakland waterfronts.'),
+  ('PUGET', 'Puget Sound', 'PNW', 'WA', 'US', 'Salish Sea ports from Seattle north to Bellingham, Washington.'),
+  ('COLUMBIA', 'Columbia River', 'PNW', 'OR', 'US', 'Lower Columbia River and Willamette River deep-draft ports.'),
+  ('INLAND', 'California Delta & Inland Waterways', 'Inland-Delta', 'CA', 'US', 'Deep-draft inland river ports connected to the San Joaquin River.')
+ON CONFLICT (code) DO UPDATE
+SET name = EXCLUDED.name,
+    region = EXCLUDED.region,
+    primary_state = EXCLUDED.primary_state,
+    country = EXCLUDED.country,
+    description = EXCLUDED.description;
+
+COMMIT;

--- a/db/seeds/ports.sql
+++ b/db/seeds/ports.sql
@@ -1,24 +1,47 @@
 BEGIN;
--- Core USWC focus ports (codes are internal labels for now)
-INSERT INTO ports (code, name, state, region, is_california, is_cascadia, pilotage_url, mx_url, tariff_url) VALUES
-('LALB', 'Los Angeles / Long Beach', 'CA', 'SoCal', TRUE, FALSE,
+
+-- Core USWC focus ports linked to geographic zones
+INSERT INTO ports (code, name, state, country, region, is_california, is_cascadia, pilotage_url, mx_url, tariff_url, zone_id) VALUES
+('LALB', 'Los Angeles / Long Beach', 'CA', 'US', 'SoCal', TRUE, FALSE,
  'https://www.portoflosangeles.org/business/pilot-service',
  'https://mxsocal.org/',
- 'https://www.polb.com/port-info/tariff/'),
-('SFBAY', 'San Francisco Bay', 'CA', 'NorCal', TRUE, FALSE,
+ 'https://www.polb.com/port-info/tariff/',
+ (SELECT id FROM port_zones WHERE code = 'SOCAL')),
+('SFBAY', 'San Francisco Bay', 'CA', 'US', 'NorCal', TRUE, FALSE,
  'https://sfbarpilots.com/new-operational/',
  'https://www.sfmx.org/bay-area-committees/hsc/',
- NULL),
-('PUGET', 'Puget Sound (Seattle/Tacoma)', 'WA', 'PNW', FALSE, TRUE,
+ NULL,
+ (SELECT id FROM port_zones WHERE code = 'NORCAL')),
+('PUGET', 'Puget Sound (Seattle/Tacoma)', 'WA', 'US', 'PNW', FALSE, TRUE,
  'https://www.pspilots.org/dispatch-information/general-guidelines-for-vessels/',
  'https://marexps.com/',
- NULL),
-('COLRIV', 'Columbia River (Astoria/Portland)', 'OR', 'PNW', FALSE, TRUE,
+ NULL,
+ (SELECT id FROM port_zones WHERE code = 'PUGET')),
+('BELLINGHAM', 'Port of Bellingham', 'WA', 'US', 'PNW', FALSE, TRUE,
+ 'https://www.pspilots.org/dispatch-information/general-guidelines-for-vessels/',
+ NULL,
+ 'https://www.portofbellingham.com/DocumentCenter/View/5930/Tariff-No-1',
+ (SELECT id FROM port_zones WHERE code = 'PUGET')),
+('COLRIV', 'Columbia River (Astoria/Portland)', 'OR', 'US', 'PNW', FALSE, TRUE,
  'https://colrip.com/',
  'https://www.pdxmex.com/resources/',
- NULL),
-('STKN', 'Port of Stockton', 'CA', 'Inland-Delta', TRUE, FALSE,
+ NULL,
+ (SELECT id FROM port_zones WHERE code = 'COLUMBIA')),
+('STKN', 'Port of Stockton', 'CA', 'US', 'Inland-Delta', TRUE, FALSE,
  NULL,
  NULL,
- 'https://www.portofstockton.com/port-tariff/');
+ 'https://www.portofstockton.com/port-tariff/',
+ (SELECT id FROM port_zones WHERE code = 'INLAND'))
+ON CONFLICT (code) DO UPDATE SET
+  name = EXCLUDED.name,
+  state = EXCLUDED.state,
+  country = EXCLUDED.country,
+  region = EXCLUDED.region,
+  is_california = EXCLUDED.is_california,
+  is_cascadia = EXCLUDED.is_cascadia,
+  pilotage_url = EXCLUDED.pilotage_url,
+  mx_url = EXCLUDED.mx_url,
+  tariff_url = EXCLUDED.tariff_url,
+  zone_id = EXCLUDED.zone_id;
+
 COMMIT;

--- a/db/seeds/terminals.sql
+++ b/db/seeds/terminals.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+INSERT INTO terminals (code, port_id, name, operator_name, is_public, notes) VALUES
+  ('LALB-PIER400', (SELECT id FROM ports WHERE code = 'LALB'), 'Pier 400', 'APM Terminals', FALSE, 'Privately operated marine terminal within the Los Angeles / Long Beach complex.'),
+  ('LALB-PIERJ', (SELECT id FROM ports WHERE code = 'LALB'), 'Pier J', 'Port of Long Beach', TRUE, 'Municipally owned berth managed by the Port of Long Beach.'),
+  ('BLI-CRUISE', (SELECT id FROM ports WHERE code = 'BELLINGHAM'), 'Bellingham Cruise Terminal', 'Port of Bellingham', TRUE, 'Publicly owned gateway for Alaska Marine Highway and seasonal cruise traffic.')
+ON CONFLICT (code) DO UPDATE SET
+  port_id = EXCLUDED.port_id,
+  name = EXCLUDED.name,
+  operator_name = EXCLUDED.operator_name,
+  is_public = EXCLUDED.is_public,
+  notes = EXCLUDED.notes;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a port_zones table and new terminals table while wiring zone→port foreign keys into the schema
- define SQLAlchemy models/relationships for port zones and publicly flagged terminals
- seed zones, ports, and example public terminals including Puget Sound’s Bellingham terminal

## Testing
- python -m compileall src


------
https://chatgpt.com/codex/tasks/task_e_68d7399cdc7c8321924ea84caebe4386