### PR TITLE
Handle manual tug optional service in quick estimate

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -465,12 +465,22 @@
               <h4 class="font-semibold mb-2">Optional Services (Estimates)</h4>
               <div class="space-y-2">
                 <template x-for="s in (estimate && estimate.optional_services ? estimate.optional_services : [])" :key="s.service">
-                  <div class="flex justify-between text-sm">
-                    <span>
-                      <span x-text="s.service"></span>
-                      <span class="text-xs text-gray-500" x-text="`(${s.note})`"></span>
-                    </span>
-                    <span class="font-mono" x-text="`$${Number(s.estimated_low).toLocaleString()} - $${Number(s.estimated_high).toLocaleString()}`"></span>
+                  <div class="flex justify-between text-sm gap-3">
+                    <div>
+                      <div class="font-medium" x-text="s.service"></div>
+                      <div class="text-xs text-gray-500" x-text="s.note"></div>
+                      <template x-if="s.manual_entry">
+                        <div class="text-xs text-amber-600 font-semibold mt-1">Manual quote required</div>
+                      </template>
+                    </div>
+                    <div class="text-right font-mono">
+                      <template x-if="s.estimated_low !== undefined && s.estimated_high !== undefined">
+                        <span x-text="`$${Number(s.estimated_low).toLocaleString()} - $${Number(s.estimated_high).toLocaleString()}`"></span>
+                      </template>
+                      <template x-if="s.manual_entry">
+                        <span class="text-xs text-gray-500">Add custom</span>
+                      </template>
+                    </div>
                   </div>
                 </template>
               </div>

--- a/src/maritime_mvp/api/main.py
+++ b/src/maritime_mvp/api/main.py
@@ -1023,9 +1023,19 @@ def estimate(
         if include_optional:
             optional_services = [
                 {"service": "Pilotage", "estimated_low": 5000, "estimated_high": 15000, "note": "Varies by size/draft"},
-                {"service": "Tugboat Assist", "estimated_low": 3000, "estimated_high": 8000, "note": "Depends on maneuvering"},
+                {
+                    "service": "Tugboat Assist",
+                    "manual_entry": True,
+                    "note": "Coordinate with local tug operator; add negotiated rate manually.",
+                },
                 {"service": "Line Handling", "estimated_low": 1000, "estimated_high": 2500, "note": "Mooring/unmooring"},
             ]
+
+        optional_estimates = [
+            svc
+            for svc in optional_services
+            if "estimated_low" in svc and "estimated_high" in svc
+        ]
 
         return {
             "port_code": port_code,
@@ -1039,8 +1049,8 @@ def estimate(
             ],
             "optional_services": optional_services,
             "total": str(total),
-            "total_with_optional_low": str(total + sum(s["estimated_low"] for s in optional_services)),
-            "total_with_optional_high": str(total + sum(s["estimated_high"] for s in optional_services)),
+            "total_with_optional_low": str(total + sum(s["estimated_low"] for s in optional_estimates)),
+            "total_with_optional_high": str(total + sum(s["estimated_high"] for s in optional_estimates)),
             "disclaimer": "Estimate only. Verify against official tariffs/guidance and your negotiated contracts.",
         }
     except HTTPException:

--- a/tests/test_fee_engine_optional_services.py
+++ b/tests/test_fee_engine_optional_services.py
@@ -131,3 +131,9 @@ def test_estimate_endpoint_excludes_legacy_launch_service(monkeypatch):
     services = payload.get("optional_services", [])
     assert services, "expected optional services list to be populated"
     assert all("Launch" not in svc["service"] for svc in services)
+    tug = next((svc for svc in services if svc["service"] == "Tugboat Assist"), None)
+    assert tug is not None, "expected tug service entry"
+    assert tug.get("manual_entry") is True
+    assert "estimated_low" not in tug and "estimated_high" not in tug
+    assert payload["total_with_optional_low"] == "6100.00"
+    assert payload["total_with_optional_high"] == "17600.00"


### PR DESCRIPTION
## Summary
- mark the legacy tug optional service as a manual entry instead of returning a faux estimate
- exclude manual-only optional items from quick-estimate optional total calculations
- update the frontend display and tests to reflect the mixed manual/estimated optional services output

## Testing
- pytest tests/test_fee_engine_optional_services.py


------
https://chatgpt.com/codex/tasks/task_e_68d84ecedab48321ad3c3fe0f6a1d5c1