### PR TITLE
Add pilotage rate registry loader and registry-driven calculations

### DIFF
--- a/src/maritime_mvp/rules/rates_loader.py
+++ b/src/maritime_mvp/rules/rates_loader.py
@@ -1,0 +1,157 @@
+"""Pilotage rate registry loader."""
+from __future__ import annotations
+
+import json
+import os
+from datetime import date, datetime
+from decimal import Decimal
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+__all__ = [
+    "MISSING_RATE_FIELD",
+    "MissingRateField",
+    "load_pilotage_rates",
+]
+
+
+class MissingRateField(KeyError):
+    """Raised when an expected field is missing from the rate registry."""
+
+    def __init__(self, field_path: str):
+        super().__init__(field_path)
+        self.field_path = field_path
+
+    def __str__(self) -> str:  # pragma: no cover - inherited KeyError repr is noisy
+        return f"missing required rate field: {self.field_path}"
+
+
+# Backwards-compatible alias for callers expecting a constant name.
+MISSING_RATE_FIELD = MissingRateField
+
+_DEFAULT_REGISTRY_PATH = Path(__file__).with_name("rates_registry.json")
+
+_REQUIRED_VERSION_KEYS = {"effective", "bar", "bay", "river", "surcharges", "extras"}
+_REQUIRED_BAR_KEYS = {"base_fee", "per_foot_rate", "draft_multiplier", "min_total", "max_total"}
+_REQUIRED_BAY_KEYS = {"per_foot_rate", "minimum"}
+_REQUIRED_RIVER_KEYS = {"per_foot_rate", "minimum"}
+_REQUIRED_SURCHARGE_KEYS = {"weekend_multiplier", "holiday_multiplier", "night_flat"}
+
+
+def _resolve_registry_path(path: str | os.PathLike[str] | None) -> Path:
+    if path is not None:
+        return Path(path)
+    override = os.getenv("PILOTAGE_RATES_PATH")
+    if override:
+        return Path(override)
+    return _DEFAULT_REGISTRY_PATH
+
+
+@lru_cache(maxsize=None)
+def _load_registry(path_str: str) -> Dict[str, Any]:
+    path = Path(path_str)
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, Mapping):
+        raise ValueError("rates registry must be a mapping of port zone to versions")
+    return dict(data)
+
+
+def _ensure_keys(zone: str, record: Mapping[str, Any]) -> None:
+    for key in _REQUIRED_VERSION_KEYS:
+        if key not in record:
+            raise MISSING_RATE_FIELD(f"{zone}.{key}")
+
+    for key in _REQUIRED_BAR_KEYS:
+        if key not in record["bar"]:
+            raise MISSING_RATE_FIELD(f"{zone}.bar.{key}")
+
+    for key in _REQUIRED_BAY_KEYS:
+        if key not in record["bay"]:
+            raise MISSING_RATE_FIELD(f"{zone}.bay.{key}")
+
+    for key in _REQUIRED_RIVER_KEYS:
+        if key not in record["river"]:
+            raise MISSING_RATE_FIELD(f"{zone}.river.{key}")
+
+    for key in _REQUIRED_SURCHARGE_KEYS:
+        if key not in record["surcharges"]:
+            raise MISSING_RATE_FIELD(f"{zone}.surcharges.{key}")
+
+    if not isinstance(record["extras"], Mapping):
+        raise MISSING_RATE_FIELD(f"{zone}.extras")
+
+
+def _to_decimal(value: Any) -> Decimal:
+    return Decimal(str(value))
+
+
+def _normalise_version(record: Mapping[str, Any]) -> Dict[str, Any]:
+    effective = record["effective"]
+    if isinstance(effective, date):
+        effective_date = effective
+    else:
+        effective_date = datetime.strptime(str(effective), "%Y-%m-%d").date()
+
+    bar = {k: _to_decimal(record["bar"][k]) for k in _REQUIRED_BAR_KEYS}
+    bay = {k: _to_decimal(record["bay"][k]) for k in _REQUIRED_BAY_KEYS}
+    river = {k: _to_decimal(record["river"][k]) for k in _REQUIRED_RIVER_KEYS}
+    surcharges = {k: _to_decimal(record["surcharges"][k]) for k in _REQUIRED_SURCHARGE_KEYS}
+    extras = {str(k): _to_decimal(v) for k, v in record["extras"].items()}
+
+    return {
+        "effective": effective_date,
+        "bar": bar,
+        "bay": bay,
+        "river": river,
+        "surcharges": surcharges,
+        "extras": extras,
+    }
+
+
+def load_pilotage_rates(
+    port_zone: str,
+    job_date: date,
+    *,
+    registry_path: str | os.PathLike[str] | None = None,
+) -> Dict[str, Any]:
+    """Return the most recent pilotage rate definition for ``port_zone``."""
+
+    if not port_zone:
+        raise ValueError("port_zone is required")
+
+    zone = port_zone.upper()
+    path = _resolve_registry_path(registry_path)
+    registry = _load_registry(str(path))
+
+    zone_versions = registry.get(zone)
+    if not zone_versions:
+        raise KeyError(f"no pilotage rates configured for zone {zone}")
+
+    selected: Dict[str, Any] | None = None
+    selected_date: date | None = None
+    for entry in zone_versions:
+        if not isinstance(entry, Mapping):
+            raise ValueError(f"invalid registry entry for zone {zone}")
+        _ensure_keys(zone, entry)
+        version = _normalise_version(entry)
+        effective = version["effective"]
+        if effective <= job_date and (selected_date is None or effective > selected_date):
+            selected = version
+            selected_date = effective
+
+    if selected is None:
+        raise ValueError(
+            f"no pilotage rates effective on {job_date.isoformat()} for zone {zone}"
+        )
+
+    return {
+        "effective": selected["effective"],
+        "bar": dict(selected["bar"]),
+        "bay": dict(selected["bay"]),
+        "river": dict(selected["river"]),
+        "surcharges": dict(selected["surcharges"]),
+        "extras": dict(selected["extras"]),
+    }
+

--- a/src/maritime_mvp/rules/rates_registry.json
+++ b/src/maritime_mvp/rules/rates_registry.json
@@ -1,0 +1,145 @@
+{
+  "SOCAL": [
+    {
+      "effective": "2023-01-01",
+      "bar": {
+        "base_fee": 3400,
+        "per_foot_rate": 8.30,
+        "draft_multiplier": 1.12,
+        "min_total": 5000,
+        "max_total": 30000
+      },
+      "bay": {
+        "per_foot_rate": 6.10,
+        "minimum": 3200
+      },
+      "river": {
+        "per_foot_rate": 0.00,
+        "minimum": 0.00
+      },
+      "surcharges": {
+        "weekend_multiplier": 1.45,
+        "holiday_multiplier": 1.90,
+        "night_flat": 600
+      },
+      "extras": {
+        "transportation": 400,
+        "assistant_pilot": 800
+      }
+    },
+    {
+      "effective": "2024-03-15",
+      "bar": {
+        "base_fee": 3600,
+        "per_foot_rate": 8.60,
+        "draft_multiplier": 1.15,
+        "min_total": 5200,
+        "max_total": 32000
+      },
+      "bay": {
+        "per_foot_rate": 6.40,
+        "minimum": 3400
+      },
+      "river": {
+        "per_foot_rate": 0.00,
+        "minimum": 0.00
+      },
+      "surcharges": {
+        "weekend_multiplier": 1.50,
+        "holiday_multiplier": 2.00,
+        "night_flat": 650
+      },
+      "extras": {
+        "transportation": 425,
+        "assistant_pilot": 875
+      }
+    }
+  ],
+  "NORCAL": [
+    {
+      "effective": "2024-01-01",
+      "bar": {
+        "base_fee": 3550,
+        "per_foot_rate": 8.40,
+        "draft_multiplier": 1.14,
+        "min_total": 5000,
+        "max_total": 31000
+      },
+      "bay": {
+        "per_foot_rate": 6.10,
+        "minimum": 3300
+      },
+      "river": {
+        "per_foot_rate": 5.25,
+        "minimum": 2900
+      },
+      "surcharges": {
+        "weekend_multiplier": 1.45,
+        "holiday_multiplier": 1.90,
+        "night_flat": 575
+      },
+      "extras": {
+        "transportation": 410,
+        "harbor_security": 225
+      }
+    }
+  ],
+  "PUGET": [
+    {
+      "effective": "2024-01-01",
+      "bar": {
+        "base_fee": 3425,
+        "per_foot_rate": 7.95,
+        "draft_multiplier": 1.12,
+        "min_total": 4800,
+        "max_total": 29000
+      },
+      "bay": {
+        "per_foot_rate": 5.80,
+        "minimum": 3000
+      },
+      "river": {
+        "per_foot_rate": 4.75,
+        "minimum": 2700
+      },
+      "surcharges": {
+        "weekend_multiplier": 1.40,
+        "holiday_multiplier": 1.85,
+        "night_flat": 525
+      },
+      "extras": {
+        "transportation": 390,
+        "assist_boat": 210
+      }
+    }
+  ],
+  "COLUMBIA": [
+    {
+      "effective": "2024-01-01",
+      "bar": {
+        "base_fee": 3300,
+        "per_foot_rate": 7.50,
+        "draft_multiplier": 1.10,
+        "min_total": 4600,
+        "max_total": 28000
+      },
+      "bay": {
+        "per_foot_rate": 5.20,
+        "minimum": 3100
+      },
+      "river": {
+        "per_foot_rate": 4.50,
+        "minimum": 2600
+      },
+      "surcharges": {
+        "weekend_multiplier": 1.38,
+        "holiday_multiplier": 1.80,
+        "night_flat": 500
+      },
+      "extras": {
+        "transportation": 385,
+        "assistant_pilot": 780
+      }
+    }
+  ]
+}

--- a/tests/test_pilotage_rates.py
+++ b/tests/test_pilotage_rates.py
@@ -1,0 +1,116 @@
+from datetime import date, datetime
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from maritime_mvp.rules.fee_engine import FeeEngine, VesselSpecs, VoyageContext
+from maritime_mvp.rules.rates_loader import (
+    MISSING_RATE_FIELD,
+    load_pilotage_rates,
+)
+
+
+def test_load_pilotage_rates_picks_latest_effective_version(tmp_path):
+    registry = {
+        "SOCAL": [
+            {
+                "effective": "2023-01-01",
+                "bar": {
+                    "base_fee": 1000,
+                    "per_foot_rate": 5,
+                    "draft_multiplier": 1.1,
+                    "min_total": 3000,
+                    "max_total": 15000,
+                },
+                "bay": {"per_foot_rate": 2, "minimum": 500},
+                "river": {"per_foot_rate": 0, "minimum": 0},
+                "surcharges": {
+                    "weekend_multiplier": 1.5,
+                    "holiday_multiplier": 2.0,
+                    "night_flat": 400,
+                },
+                "extras": {"transportation": 200},
+            },
+            {
+                "effective": "2024-01-01",
+                "bar": {
+                    "base_fee": 1200,
+                    "per_foot_rate": 6,
+                    "draft_multiplier": 1.2,
+                    "min_total": 3500,
+                    "max_total": 18000,
+                },
+                "bay": {"per_foot_rate": 3, "minimum": 600},
+                "river": {"per_foot_rate": 0, "minimum": 0},
+                "surcharges": {
+                    "weekend_multiplier": 1.6,
+                    "holiday_multiplier": 2.1,
+                    "night_flat": 450,
+                },
+                "extras": {"transportation": 250},
+            },
+        ]
+    }
+    path = tmp_path / "rates.json"
+    path.write_text(__import__("json").dumps(registry))
+
+    rates = load_pilotage_rates("socal", date(2024, 5, 1), registry_path=path)
+
+    assert rates["effective"].isoformat() == "2024-01-01"
+    assert rates["bar"]["base_fee"] == Decimal("1200")
+    assert rates["extras"]["transportation"] == Decimal("250")
+
+
+def test_load_pilotage_rates_missing_field(tmp_path):
+    registry = {
+        "SOCAL": [
+            {
+                "effective": "2024-01-01",
+                "bar": {
+                    "per_foot_rate": 6,
+                    "draft_multiplier": 1.2,
+                    "min_total": 3500,
+                    "max_total": 18000,
+                },
+                "bay": {"per_foot_rate": 3, "minimum": 600},
+                "river": {"per_foot_rate": 0, "minimum": 0},
+                "surcharges": {
+                    "weekend_multiplier": 1.6,
+                    "holiday_multiplier": 2.1,
+                    "night_flat": 450,
+                },
+                "extras": {"transportation": 250},
+            }
+        ]
+    }
+    path = tmp_path / "rates.json"
+    path.write_text(__import__("json").dumps(registry))
+
+    with pytest.raises(MISSING_RATE_FIELD):
+        load_pilotage_rates("SOCAL", date(2024, 1, 2), registry_path=path)
+
+
+def test_calc_pilotage_uses_registry(monkeypatch):
+    engine = FeeEngine(MagicMock())
+    port = SimpleNamespace(
+        code="LALB",
+        zone=SimpleNamespace(code="SOCAL"),
+        zone_code="SOCAL",
+        state="CA",
+    )
+
+    vessel = VesselSpecs(name="Test Vessel", loa_meters=Decimal("300"), draft_meters=Decimal("12"))
+    voyage = VoyageContext(
+        previous_port_code="CNSHA",
+        arrival_port_code="LALB",
+        eta=datetime(2024, 7, 4, 21, 0, 0),
+    )
+
+    calc = engine._calc_pilotage(vessel, voyage, port)
+
+    assert calc.code == "PILOTAGE"
+    assert calc.multipliers == {"holiday": Decimal("2.00")}
+    assert calc.final_amount == Decimal("33950.00")
+    assert "SOCAL rates effective" in calc.calculation_details


### PR DESCRIPTION
## Summary
- add a pilotage rate registry loader that validates required fields and selects the latest effective version per zone
- drive FeeEngine pilotage calculations from the registry, including per-segment charges, surcharges, and extras with a legacy fallback
- cover the loader and pilotage calculation behavior with regression tests and seeded registry data

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8fc2db048832194388b323fc48f3b